### PR TITLE
fixed category-product connection and category delete route

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -4,14 +4,14 @@ const Category = require('./Category');
 const Tag = require('./Tag');
 const ProductTag = require('./ProductTag');
 
-// Products have one category
-Product.belongsTo(Category, {
+// Categories contain many products
+Category.hasMany(Product, {
   foreignKey: 'category_id',
 });
 
-// Categories contain many products
-Category.hasMany(Product, {
-  foreignKey: 'product_id',
+// Products have one category
+Product.belongsTo(Category, {
+  foreignKey: 'category_id',
 });
 
 // Many to many

--- a/routes/api/category-routes.js
+++ b/routes/api/category-routes.js
@@ -69,15 +69,19 @@ router.put('/:id', async (req, res) => {
 // Delete a category by its `id` value
 router.delete('/:id', async (req, res) => {
   try {
-    const categoryData = await Category.destroy({
-      where: {
-        id: req.params.id,
-      },
-    });
+    // Find products belonging to that category and set their category_id to null
+    const childProducts = await Product.findAll({ where: { category_id: req.params.id } });    
+    for (const product of childProducts) {
+      product.category_id = null;
+      await product.save();
+    }
+
+    const categoryData = await Category.destroy({ where: { id: req.params.id } });
     res.status(200).json(categoryData);
+
   } catch (err) {
-    res.status(500).json(err);
-  }
+      res.status(500).json(err);
+  };
 });
 
 module.exports = router;


### PR DESCRIPTION
Changed the foreignkey in the "category has many product" to category_id. It was previously product_id, which didn't refer to anything. Now a get request to categories will properly show the products belonging to each category.
Also fixed the category DELETE route which was broken due to the category table being a parent to the product table. The solution I managed was to find all the products belonging to the category to be deleted and changed their category_id to null, and then deleting said category. This avoids the error.