### PR TITLE
fixed put routes

### DIFF
--- a/routes/api/category-routes.js
+++ b/routes/api/category-routes.js
@@ -50,17 +50,12 @@ router.post('/', async (req, res) => {
 // Update a category by its `id` value
 router.put('/:id', async (req, res) => {
   try {
-    const categoryData = await Category.update(
-      {
-        category_name: req.body.category_name,
-      },
-      {
+    const [categoryData] = await Category.update(req.body, {
         where: {
           id: req.params.id,
         },
-      },
-      res.status(200).json(categoryData),
-    );
+      });
+      res.status(200).json(categoryData);
   } catch (err) {
     res.status(500).json(err);
   }

--- a/routes/api/tag-routes.js
+++ b/routes/api/tag-routes.js
@@ -49,17 +49,12 @@ router.post('/', async (req, res) => {
 // Update a tag's name by its `id` value
 router.put('/:id', async (req, res) => {
   try {
-    const tagData = await Tag.update(
-      {
-        tag_name: req.body.category_name,
-      },
-      {
+    const [tagData] = await Tag.update(req.body, {
         where: {
           id: req.params.id,
         },
-      },
-      res.status(200).json(tagData),
-    );
+      });
+      res.status(200).json(tagData);
   } catch (err) {
     res.status(500).json(err);
   }


### PR DESCRIPTION
Fixed the syntax for the put routes for tags and categories. I had to put the promise const in square brackets because the update method returns an array.